### PR TITLE
build: fixes #13 remove empty jars

### DIFF
--- a/bot-admin-open-data/pom.xml
+++ b/bot-admin-open-data/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-bot-admin-open-data</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/bot-admin/pom.xml
+++ b/bot-admin/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-bot-admin</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/bot-api-webhook/pom.xml
+++ b/bot-api-webhook/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-bot-api-webhook</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -47,7 +48,14 @@
                             <build>
                                 <from>openjdk:14</from>
                                 <assembly>
-                                    <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                    <inline>
+                                        <dependencySets>
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <unpack>false</unpack>
+                                            </dependencySet>
+                                        </dependencySets>
+                                    </inline>
                                 </assembly>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -cp '/maven/*' ai.tock.demo.webhook.StartWebhookKt</shell>

--- a/bot-api/pom.xml
+++ b/bot-api/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-bot-api</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -47,7 +48,14 @@
                             <build>
                                 <from>openjdk:14</from>
                                 <assembly>
-                                    <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                    <inline>
+                                        <dependencySets>
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <unpack>false</unpack>
+                                            </dependencySet>
+                                        </dependencySets>
+                                    </inline>
                                 </assembly>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -cp '/maven/*' ai.tock.bot.api.service.StartBotApiKt</shell>

--- a/bot-open-data/pom.xml
+++ b/bot-open-data/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-bot-open-data</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -47,7 +48,14 @@
                             <build>
                                 <from>openjdk:14</from>
                                 <assembly>
-                                    <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                    <inline>
+                                        <dependencySets>
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <unpack>false</unpack>
+                                            </dependencySet>
+                                        </dependencySets>
+                                    </inline>
                                 </assembly>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -cp '/maven/*' ai.tock.bot.open.data.StartKt</shell>

--- a/duckling/pom.xml
+++ b/duckling/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-duckling</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/kotlin-compiler/pom.xml
+++ b/kotlin-compiler/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-kotlin-compiler</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/nlp-admin/pom.xml
+++ b/nlp-admin/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-nlp-admin</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>

--- a/nlp-api/pom.xml
+++ b/nlp-api/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-nlp-api</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -51,7 +52,14 @@
                             <build>
                                 <from>openjdk:14</from>
                                 <assembly>
-                                    <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                    <inline>
+                                        <dependencySets>
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <unpack>false</unpack>
+                                            </dependencySet>
+                                        </dependencySets>
+                                    </inline>
                                 </assembly>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -cp '/maven/*' ai.tock.nlp.api.StartNlpServiceKt</shell>

--- a/nlp-build-model-worker/pom.xml
+++ b/nlp-build-model-worker/pom.xml
@@ -27,6 +27,7 @@
     </parent>
 
     <artifactId>tock-docker-nlp-build-model-worker</artifactId>
+    <packaging>pom</packaging>
 
     <dependencies>
         <dependency>
@@ -51,7 +52,14 @@
                             <build>
                                 <from>openjdk:14</from>
                                 <assembly>
-                                    <descriptorRef>artifact-with-dependencies</descriptorRef>
+                                    <inline>
+                                        <dependencySets>
+                                            <dependencySet>
+                                                <useProjectArtifact>false</useProjectArtifact>
+                                                <unpack>false</unpack>
+                                            </dependencySet>
+                                        </dependencySets>
+                                    </inline>
                                 </assembly>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -Dtock_nlp_model_refresh=false -cp '/maven/*' ai.tock.nlp.build.StartBuildWorkerKt</shell>


### PR DESCRIPTION
Build warnings reduced from 13 to 1.
Did not notice any difference (except empty JARs) by comparing `target` folders recursively before/after the change.