### PR TITLE
:sparkles: Corporate proxy with custom docker buildx

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ You will need [Maven](https://maven.apache.org/) and [Git](https://git-scm.com/)
     mvn package docker:build
 ```    
 
+### Build images under corporate proxy
+
+The docker build is based on buildx so build occurs on a buildx builder node, this node run as a docker container that unfortunatly doesn't inherit proxy environment variables.
+
+To set your corporate proxy environment variable and use your coporate proxy during docker build stage you will need to define a custom docker buildx builder like this :
+```sh
+docker buildx create\
+   --driver-opt env.http_proxy="http://yourcoporateproxy:3128"\
+   --driver-opt env.https_proxy="http://yourcoporateproxy:3128"\
+   --name builder_with_corporate_proxy
+```
+
+*Note that the builder name builder_with_corporate_proxy can be customized.*
+
+Then define this environment variable :
+```sh
+BUILDX_BUILDER=builder_with_corporate_proxy mvn package docker:build
+```
+
+If needed you can remove / delete this builder using : `docker buildx rm builder_with_corporate_proxy`
+
 ## Run Mongo for Apple Silicon
 
 ```sh 

--- a/bot-admin-open-data/pom.xml
+++ b/bot-admin-open-data/pom.xml
@@ -109,6 +109,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-admin-open-data/pom.xml
+++ b/bot-admin-open-data/pom.xml
@@ -109,7 +109,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-admin/pom.xml
+++ b/bot-admin/pom.xml
@@ -111,6 +111,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-admin/pom.xml
+++ b/bot-admin/pom.xml
@@ -111,7 +111,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-api-webhook/pom.xml
+++ b/bot-api-webhook/pom.xml
@@ -72,6 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-api-webhook/pom.xml
+++ b/bot-api-webhook/pom.xml
@@ -72,7 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-api/pom.xml
+++ b/bot-api/pom.xml
@@ -72,6 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-api/pom.xml
+++ b/bot-api/pom.xml
@@ -72,7 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-open-data/pom.xml
+++ b/bot-open-data/pom.xml
@@ -72,6 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/bot-open-data/pom.xml
+++ b/bot-open-data/pom.xml
@@ -72,7 +72,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/duckling/pom.xml
+++ b/duckling/pom.xml
@@ -76,7 +76,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/duckling/pom.xml
+++ b/duckling/pom.xml
@@ -76,6 +76,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/kotlin-compiler/pom.xml
+++ b/kotlin-compiler/pom.xml
@@ -74,7 +74,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/kotlin-compiler/pom.xml
+++ b/kotlin-compiler/pom.xml
@@ -74,6 +74,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-admin/pom.xml
+++ b/nlp-admin/pom.xml
@@ -107,6 +107,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-admin/pom.xml
+++ b/nlp-admin/pom.xml
@@ -107,7 +107,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-api/pom.xml
+++ b/nlp-api/pom.xml
@@ -80,7 +80,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-api/pom.xml
+++ b/nlp-api/pom.xml
@@ -80,6 +80,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-build-model-worker/pom.xml
+++ b/nlp-build-model-worker/pom.xml
@@ -84,7 +84,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
-                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>

--- a/nlp-build-model-worker/pom.xml
+++ b/nlp-build-model-worker/pom.xml
@@ -84,6 +84,7 @@
                                     <tag>${project.version}</tag>
                                 </tags>
                                 <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!-- Frabic IO doesn't use builder defined in environment variable, enforcing it, see #33 -->
                                     <platforms>
                                         <platform>linux/amd64</platform>
                                         <platform>linux/arm64</platform>


### PR DESCRIPTION
Documentation for corporate proxy & enforcement of the buildx env variable.

Fixes #33 