### PR TITLE
[FIX] Add linux/amd64 platform to Tock Gen AI Orchestrator

### DIFF
--- a/gen-ai-orchestrator-server/pom.xml
+++ b/gen-ai-orchestrator-server/pom.xml
@@ -62,6 +62,13 @@
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
                                 </tags>
+                                <buildx>
+                                    <builderName>${env.BUILDX_BUILDER}</builderName> <!--Fabric8 doesn't use builder defined in environment variable, enforcing it, see #33 -->
+                                    <platforms>
+                                        <platform>linux/amd64</platform>
+                                        <platform>linux/arm64</platform>
+                                    </platforms>
+                                </buildx>
                             </build>
                             <run>
                                 <ports>


### PR DESCRIPTION
In addition to linux/arm64/v8, set os architecture for docker build to amd64