### PR TITLE
Update README: use the correct docker‑compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In order to reach the mongo database from a client
     #get the last tag
     curl -o .env https://raw.githubusercontent.com/theopenconversationkit/tock-docker/master/.env
     #launch the stack
-    docker-compose -f docker-compose-bot.yml up
+    docker-compose -f docker-compose-bot-webhook.yml up
 ``` 
 
 - Then you have to setup:


### PR DESCRIPTION
The README originally pointed to `docker-compose-bot.yml` in the final command, but all the preceding steps download and use `docker-compose-bot-webhook.yml`.  This change updates the launch command to match the actual file being downloaded so that users can run the stack without having to edit the README manually.